### PR TITLE
ppx: allow dropping arbitrary values with `[@drop_default]`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 - Support `Ptype_open`, e.g. `type u = X.(x) [@@deriving json]`
   ([#60](https://github.com/melange-community/melange-json/pull/60))
+- Add support for `[@drop_default]` with `[@default]` to omit fields
+  from JSON output when their value matches the default. Equality is
+  resolved via `equal_<type>` functions in scope by default, but a custom comparison
+  function can be provided directly, e.g. `[@json.drop_default Int.equal]`
+  ([#77](https://github.com/melange-community/melange-json/pull/77))
+- Add `Melange_json.equal` for comparing two JSON values, and
+  `[@drop_default_if_json_equal]` as an alternative to `[@.drop_default]`
+  that compares values at the JSON level
+  ([#77](https://github.com/melange-community/melange-json/pull/77))
 
 ## 2.0.0 (2025-03-11)
 

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -214,6 +214,16 @@ module To_json = struct
                   match [%e x] with
                   | Stdlib.Option.None -> Js.Undefined.empty
                   | Stdlib.Option.Some _ -> Js.Undefined.return [%e v]]
+            | `Drop_default (cmp, def) ->
+                [%expr
+                  if [%e cmp] [%e x] [%e def] then Js.Undefined.empty
+                  else Js.Undefined.return [%e v]]
+            | `Drop_default_if_json_equal def ->
+                [%expr
+                  let json = [%e v] in
+                  if Melange_json.equal json [%e derive ld.pld_type def]
+                  then Js.Undefined.empty
+                  else Js.Undefined.return json]
           in
           map_loc lident k, v)
     in

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -208,6 +208,16 @@ module To_json = struct
                   match [%e x] with
                   | Stdlib.Option.None -> [%e ebnds]
                   | Stdlib.Option.Some _ -> ([%e k], [%e v]) :: [%e ebnds]]
+            | `Drop_default (cmp, def) ->
+                [%expr
+                  if [%e cmp] [%e x] [%e def] then [%e ebnds]
+                  else ([%e k], [%e v]) :: [%e ebnds]]
+            | `Drop_default_if_json_equal def ->
+                [%expr
+                  let json = [%e v] in
+                  if Melange_json.equal json [%e derive ld.pld_type def]
+                  then [%e ebnds]
+                  else ([%e k], json) :: [%e ebnds]]
           in
           [%expr
             let [%p pbnds] = [%e ebnds] in

--- a/ppx/test/dune
+++ b/ppx/test/dune
@@ -13,4 +13,3 @@
  (applies_to ptype_open)
  (enabled_if
   (>= %{ocaml_version} 5.2.0)))
-

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -1222,6 +1222,252 @@
     let _ = drop_default_option_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
   $ cat <<"EOF" | run
+  > type drop_default_default_eq = { a: int; b: int; [@default 1] [@json.drop_default] } [@@deriving json]
+  > EOF
+  type drop_default_default_eq = {
+    a : int;
+    b : int; [@default 1] [@json.drop_default]
+  }
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : drop_default_default_eq) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_default_eq_of_json =
+      (fun x ->
+         if
+           Stdlib.not
+             (Stdlib.( && )
+                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( && )
+                   (Stdlib.not (Js.Array.isArray x))
+                   (Stdlib.not
+                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+         then Melange_json.of_json_error ~json:x "expected a JSON object";
+         let fs =
+           (Obj.magic x
+             : < a : Js.Json.t Js.undefined ; b : Js.Json.t Js.undefined >
+               Js.t)
+         in
+         {
+           a =
+             (match Js.Undefined.toOption fs##a with
+             | Stdlib.Option.Some v -> int_of_json v
+             | Stdlib.Option.None ->
+                 Melange_json.of_json_error ~json:x
+                   "expected field \"a\" to be present");
+           b =
+             (match Js.Undefined.toOption fs##b with
+             | Stdlib.Option.Some v -> int_of_json v
+             | Stdlib.Option.None -> 1);
+         }
+        : Js.Json.t -> drop_default_default_eq)
+  
+    let _ = drop_default_default_eq_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_default_eq_to_json =
+      (fun x ->
+         match x with
+         | { a = x_a; b = x_b } ->
+             (Obj.magic
+                [%mel.obj
+                  {
+                    a = int_to_json x_a;
+                    b =
+                      (if equal_int x_b 1 then Js.Undefined.empty
+                       else Js.Undefined.return (int_to_json x_b));
+                  }]
+               : Js.Json.t)
+        : drop_default_default_eq -> Js.Json.t)
+  
+    let _ = drop_default_default_eq_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
+  > type variant_any = Other of Yojson.Basic.t [@allow_any] | Foo [@@deriving json]
+  > EOF
+  type variant_any = Other of Yojson.Basic.t [@allow_any] | Foo
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : variant_any) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec variant_any_of_json =
+      (fun x ->
+         if Js.Array.isArray x then
+           let array = (Obj.magic x : Js.Json.t array) in
+           let len = Js.Array.length array in
+           if Stdlib.( > ) len 0 then
+             let tag = Js.Array.unsafe_get array 0 in
+             if Stdlib.( = ) (Js.typeof tag) "string" then
+               let tag = (Obj.magic tag : string) in
+               if Stdlib.( = ) tag "Foo" then
+                 if Stdlib.( <> ) len 1 then Other x else Foo
+               else Other x
+             else Other x
+           else Other x
+         else Other x
+        : Js.Json.t -> variant_any)
+  
+    let _ = variant_any_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec variant_any_to_json =
+      (fun x ->
+         match x with
+         | Other x_0 -> x_0
+         | Foo ->
+             (Obj.magic [| (Obj.magic "Foo" : Js.Json.t) |] : Js.Json.t)
+        : variant_any -> Js.Json.t)
+  
+    let _ = variant_any_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
+  > type drop_default = { a: int; b: int; [@default 1] [@json.drop_default (fun a b -> if compare a b = 0 then true else false)] } [@@deriving json]
+  > EOF
+  type drop_default = {
+    a : int;
+    b : int;
+        [@default 1]
+        [@json.drop_default
+          fun a b -> if compare a b = 0 then true else false]
+  }
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : drop_default) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_of_json =
+      (fun x ->
+         if
+           Stdlib.not
+             (Stdlib.( && )
+                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( && )
+                   (Stdlib.not (Js.Array.isArray x))
+                   (Stdlib.not
+                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+         then Melange_json.of_json_error ~json:x "expected a JSON object";
+         let fs =
+           (Obj.magic x
+             : < a : Js.Json.t Js.undefined ; b : Js.Json.t Js.undefined >
+               Js.t)
+         in
+         {
+           a =
+             (match Js.Undefined.toOption fs##a with
+             | Stdlib.Option.Some v -> int_of_json v
+             | Stdlib.Option.None ->
+                 Melange_json.of_json_error ~json:x
+                   "expected field \"a\" to be present");
+           b =
+             (match Js.Undefined.toOption fs##b with
+             | Stdlib.Option.Some v -> int_of_json v
+             | Stdlib.Option.None -> 1);
+         }
+        : Js.Json.t -> drop_default)
+  
+    let _ = drop_default_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_to_json =
+      (fun x ->
+         match x with
+         | { a = x_a; b = x_b } ->
+             (Obj.magic
+                [%mel.obj
+                  {
+                    a = int_to_json x_a;
+                    b =
+                      (if
+                         (fun a b ->
+                           if compare a b = 0 then true else false)
+                           x_b 1
+                       then Js.Undefined.empty
+                       else Js.Undefined.return (int_to_json x_b));
+                  }]
+               : Js.Json.t)
+        : drop_default -> Js.Json.t)
+  
+    let _ = drop_default_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
+  > type drop_default_if_json_equal = { a: int; b: int; [@default 1] [@json.drop_default_if_json_equal] } [@@deriving json]
+  > EOF
+  type drop_default_if_json_equal = {
+    a : int;
+    b : int; [@default 1] [@json.drop_default_if_json_equal]
+  }
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : drop_default_if_json_equal) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_if_json_equal_of_json =
+      (fun x ->
+         if
+           Stdlib.not
+             (Stdlib.( && )
+                (Stdlib.( = ) (Js.typeof x) "object")
+                (Stdlib.( && )
+                   (Stdlib.not (Js.Array.isArray x))
+                   (Stdlib.not
+                      (Stdlib.( == ) (Obj.magic x : 'a Js.null) Js.null))))
+         then Melange_json.of_json_error ~json:x "expected a JSON object";
+         let fs =
+           (Obj.magic x
+             : < a : Js.Json.t Js.undefined ; b : Js.Json.t Js.undefined >
+               Js.t)
+         in
+         {
+           a =
+             (match Js.Undefined.toOption fs##a with
+             | Stdlib.Option.Some v -> int_of_json v
+             | Stdlib.Option.None ->
+                 Melange_json.of_json_error ~json:x
+                   "expected field \"a\" to be present");
+           b =
+             (match Js.Undefined.toOption fs##b with
+             | Stdlib.Option.Some v -> int_of_json v
+             | Stdlib.Option.None -> 1);
+         }
+        : Js.Json.t -> drop_default_if_json_equal)
+  
+    let _ = drop_default_if_json_equal_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_if_json_equal_to_json =
+      (fun x ->
+         match x with
+         | { a = x_a; b = x_b } ->
+             (Obj.magic
+                [%mel.obj
+                  {
+                    a = int_to_json x_a;
+                    b =
+                      (let json = int_to_json x_b in
+                       if Melange_json.equal json (int_to_json 1) then
+                         Js.Undefined.empty
+                       else Js.Undefined.return json);
+                  }]
+               : Js.Json.t)
+        : drop_default_if_json_equal -> Js.Json.t)
+  
+    let _ = drop_default_if_json_equal_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
   > type variant_any = Other of Yojson.Basic.t [@allow_any] | Foo [@@deriving json]
   > EOF
   type variant_any = Other of Yojson.Basic.t [@allow_any] | Foo

--- a/ppx/test/ppx_deriving_json_js_errors.t
+++ b/ppx/test/ppx_deriving_json_js_errors.t
@@ -4,6 +4,47 @@
   File "-", line 1, characters 11-41:
   1 | type t = { a: int option; [@drop_default] } [@@deriving json]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: found [@drop_default] attribute without [@option]
+  Error: [@drop_default] requires either [@option] or [@default]
   [1]
 
+  $ echo 'type t = { a: int option; [@option] [@default Some 0] [@drop_default] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 11-69:
+  1 | type t = { a: int option; [@option] [@default Some 0] [@drop_default] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default] cannot be used with both [@option] and [@default]
+  [1]
+
+  $ echo 'type t = { a: int; [@drop_default (=)] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 11-38:
+  1 | type t = { a: int; [@drop_default (=)] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default expr] requires [@default]
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@drop_default (=)] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 11-55:
+  1 | type t = { a: int option; [@option] [@drop_default (=)] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default expr] cannot be used with [@option]
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@drop_default] [@drop_default_if_json_equal] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 11-81:
+  1 | type t = { a: int option; [@option] [@drop_default] [@drop_default_if_json_equal] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default] and [@drop_default_if_json_equal] are mutually exclusive
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@default Some 0] [@drop_default_if_json_equal] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 11-83:
+  1 | type t = { a: int option; [@option] [@default Some 0] [@drop_default_if_json_equal] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default_if_json_equal] cannot be used with both [@option] and [@default]. Use [@json.default] only.
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@drop_default_if_json_equal] } [@@deriving json]' | ../browser/ppx_deriving_json_js_test.exe -impl -
+  File "-", line 1, characters 11-65:
+  1 | type t = { a: int option; [@option] [@drop_default_if_json_equal] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default_if_json_equal] cannot be used with [@option]. Use [@drop_default] instead.
+  [1]

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -927,3 +927,214 @@
   
     let _ = drop_default_option_to_json
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
+  > type drop_default = { a: int; b: int; [@default 1] [@json.drop_default (fun a b -> if compare a b = 0 then true else false)] } [@@deriving json]
+  > EOF
+  type drop_default = {
+    a : int;
+    b : int;
+        [@default 1]
+        [@json.drop_default
+          fun a b -> if compare a b = 0 then true else false]
+  }
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : drop_default) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_of_json =
+      (fun x ->
+         match x with
+         | `Assoc fs ->
+             let x_a = ref Stdlib.Option.None in
+             let x_b = ref (Stdlib.Option.Some 1) in
+             let rec iter = function
+               | [] -> ()
+               | (n', v) :: fs ->
+                   (match n' with
+                   | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
+                   | "b" -> x_b := Stdlib.Option.Some (int_of_json v)
+                   | name ->
+                       Melange_json.of_json_error ~json:x
+                         (Stdlib.Printf.sprintf
+                            {|did not expect field "%s"|} name));
+                   iter fs
+             in
+             iter fs;
+             {
+               a =
+                 (match Stdlib.( ! ) x_a with
+                 | Stdlib.Option.Some v -> v
+                 | Stdlib.Option.None ->
+                     Melange_json.of_json_error ~json:x
+                       "expected field \"a\"");
+               b =
+                 (match Stdlib.( ! ) x_b with
+                 | Stdlib.Option.Some v -> v
+                 | Stdlib.Option.None -> 1);
+             }
+         | _ -> Melange_json.of_json_error ~json:x "expected a JSON object"
+        : Yojson.Basic.t -> drop_default)
+  
+    let _ = drop_default_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_to_json =
+      (fun x ->
+         match x with
+         | { a = x_a; b = x_b } ->
+             `Assoc
+               (let bnds__001_ = [] in
+                let bnds__001_ =
+                  if
+                    (fun a b -> if compare a b = 0 then true else false)
+                      x_b 1
+                  then bnds__001_
+                  else ("b", int_to_json x_b) :: bnds__001_
+                in
+                let bnds__001_ = ("a", int_to_json x_a) :: bnds__001_ in
+                bnds__001_)
+        : drop_default -> Yojson.Basic.t)
+  
+    let _ = drop_default_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
+  > type drop_default_default_eq = { a: int; b: int; [@default 1] [@json.drop_default] } [@@deriving json]
+  > EOF
+  type drop_default_default_eq = {
+    a : int;
+    b : int; [@default 1] [@json.drop_default]
+  }
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : drop_default_default_eq) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_default_eq_of_json =
+      (fun x ->
+         match x with
+         | `Assoc fs ->
+             let x_a = ref Stdlib.Option.None in
+             let x_b = ref (Stdlib.Option.Some 1) in
+             let rec iter = function
+               | [] -> ()
+               | (n', v) :: fs ->
+                   (match n' with
+                   | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
+                   | "b" -> x_b := Stdlib.Option.Some (int_of_json v)
+                   | name ->
+                       Melange_json.of_json_error ~json:x
+                         (Stdlib.Printf.sprintf
+                            {|did not expect field "%s"|} name));
+                   iter fs
+             in
+             iter fs;
+             {
+               a =
+                 (match Stdlib.( ! ) x_a with
+                 | Stdlib.Option.Some v -> v
+                 | Stdlib.Option.None ->
+                     Melange_json.of_json_error ~json:x
+                       "expected field \"a\"");
+               b =
+                 (match Stdlib.( ! ) x_b with
+                 | Stdlib.Option.Some v -> v
+                 | Stdlib.Option.None -> 1);
+             }
+         | _ -> Melange_json.of_json_error ~json:x "expected a JSON object"
+        : Yojson.Basic.t -> drop_default_default_eq)
+  
+    let _ = drop_default_default_eq_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_default_eq_to_json =
+      (fun x ->
+         match x with
+         | { a = x_a; b = x_b } ->
+             `Assoc
+               (let bnds__001_ = [] in
+                let bnds__001_ =
+                  if equal_int x_b 1 then bnds__001_
+                  else ("b", int_to_json x_b) :: bnds__001_
+                in
+                let bnds__001_ = ("a", int_to_json x_a) :: bnds__001_ in
+                bnds__001_)
+        : drop_default_default_eq -> Yojson.Basic.t)
+  
+    let _ = drop_default_default_eq_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+  $ cat <<"EOF" | run
+  > type drop_default_if_json_equal = { a: int; b: int; [@default 1] [@json.drop_default_if_json_equal] } [@@deriving json]
+  > EOF
+  type drop_default_if_json_equal = {
+    a : int;
+    b : int; [@default 1] [@json.drop_default_if_json_equal]
+  }
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : drop_default_if_json_equal) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_if_json_equal_of_json =
+      (fun x ->
+         match x with
+         | `Assoc fs ->
+             let x_a = ref Stdlib.Option.None in
+             let x_b = ref (Stdlib.Option.Some 1) in
+             let rec iter = function
+               | [] -> ()
+               | (n', v) :: fs ->
+                   (match n' with
+                   | "a" -> x_a := Stdlib.Option.Some (int_of_json v)
+                   | "b" -> x_b := Stdlib.Option.Some (int_of_json v)
+                   | name ->
+                       Melange_json.of_json_error ~json:x
+                         (Stdlib.Printf.sprintf
+                            {|did not expect field "%s"|} name));
+                   iter fs
+             in
+             iter fs;
+             {
+               a =
+                 (match Stdlib.( ! ) x_a with
+                 | Stdlib.Option.Some v -> v
+                 | Stdlib.Option.None ->
+                     Melange_json.of_json_error ~json:x
+                       "expected field \"a\"");
+               b =
+                 (match Stdlib.( ! ) x_b with
+                 | Stdlib.Option.Some v -> v
+                 | Stdlib.Option.None -> 1);
+             }
+         | _ -> Melange_json.of_json_error ~json:x "expected a JSON object"
+        : Yojson.Basic.t -> drop_default_if_json_equal)
+  
+    let _ = drop_default_if_json_equal_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec drop_default_if_json_equal_to_json =
+      (fun x ->
+         match x with
+         | { a = x_a; b = x_b } ->
+             `Assoc
+               (let bnds__001_ = [] in
+                let bnds__001_ =
+                  let json = int_to_json x_b in
+                  if Melange_json.equal json (int_to_json 1) then bnds__001_
+                  else ("b", json) :: bnds__001_
+                in
+                let bnds__001_ = ("a", int_to_json x_a) :: bnds__001_ in
+                bnds__001_)
+        : drop_default_if_json_equal -> Yojson.Basic.t)
+  
+    let _ = drop_default_if_json_equal_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]

--- a/ppx/test/ppx_deriving_json_native_errors.t
+++ b/ppx/test/ppx_deriving_json_native_errors.t
@@ -4,6 +4,47 @@
   File "-", line 1, characters 11-41:
   1 | type t = { a: int option; [@drop_default] } [@@deriving json]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: found [@drop_default] attribute without [@option]
+  Error: [@drop_default] requires either [@option] or [@default]
   [1]
 
+  $ echo 'type t = { a: int option; [@option] [@default Some 0] [@drop_default] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 11-69:
+  1 | type t = { a: int option; [@option] [@default Some 0] [@drop_default] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default] cannot be used with both [@option] and [@default]
+  [1]
+
+  $ echo 'type t = { a: int; [@drop_default (=)] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 11-38:
+  1 | type t = { a: int; [@drop_default (=)] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default expr] requires [@default]
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@drop_default (=)] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 11-55:
+  1 | type t = { a: int option; [@option] [@drop_default (=)] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default expr] cannot be used with [@option]
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@drop_default] [@drop_default_if_json_equal] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 11-81:
+  1 | type t = { a: int option; [@option] [@drop_default] [@drop_default_if_json_equal] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default] and [@drop_default_if_json_equal] are mutually exclusive
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@default Some 0] [@drop_default_if_json_equal] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 11-83:
+  1 | type t = { a: int option; [@option] [@default Some 0] [@drop_default_if_json_equal] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default_if_json_equal] cannot be used with both [@option] and [@default]. Use [@json.default] only.
+  [1]
+
+  $ echo 'type t = { a: int option; [@option] [@drop_default_if_json_equal] } [@@deriving json]' | ../native/ppx_deriving_json_native_test.exe -impl -
+  File "-", line 1, characters 11-65:
+  1 | type t = { a: int option; [@option] [@drop_default_if_json_equal] } [@@deriving json]
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: [@drop_default_if_json_equal] cannot be used with [@option]. Use [@drop_default] instead.
+  [1]

--- a/src/melange_json.mli
+++ b/src/melange_json.mli
@@ -437,3 +437,5 @@ val declassify :
   | `String of string ] ->
   json
 (** Declassify a variant type into a JSON value. *)
+
+val equal : json -> json -> bool

--- a/src/native/melange_json.ml
+++ b/src/native/melange_json.ml
@@ -134,3 +134,5 @@ module Primitives = struct
   let list_to_json = To_json.list
   let array_to_json = To_json.array
 end
+
+let equal = Yojson.Basic.equal


### PR DESCRIPTION
This PR allows `[@drop_default]` to drop default values provided by `[@default]`.
It also changes `[@drop_default]` to potentially accept a function for comparison. If no function is provided, then structural equality is used.

`[@drop_default]` with `[@option]` remains unchanged

Not sure if `ppx_compare` works with melange. If yes I can change this PR to be closer to how [ppx_yojson_conv](https://github.com/janestreet/ppx_yojson_conv?tab=readme-ov-file#specifying-equality-for-yojson_drop_default) implements their similar feature

#### Motivation

It brings `melange-json` closer to being able to substitute [atd](https://github.com/ahrefs/atd), and makes sense as an extension of the `[@drop_default]` attribute, which currently makes `melange-json` unable to fully express some records without making fields needlessly optional 