### PR TITLE
Support @json.compact_variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- PPX: Add `[@@json.compact_variants]` attribute for variant and polyvariant
+  types. Encodes constructors without arguments as plain JSON strings and
+  constructors with arguments as JSON arrays `["ConstructorName", arg1, ...]`.
 - Support `Ptype_open`, e.g. `type u = X.(x) [@@deriving json]`
   ([#60](https://github.com/melange-community/melange-json/pull/60))
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,34 @@ let json = to_json B
 (* "bbb" *)
 ```
 
+#### `[@@json.compact_variants]`: compact encoding for variants and polyvariants
+
+The `[@@json.compact_variants]` attribute changes the JSON encoding of variant
+and polyvariant types to a compact form:
+
+- Constructors **without arguments** are encoded as plain JSON strings.
+- Constructors **with arguments** are encoded as JSON arrays
+  `["ConstructorName", arg1, ...]`.
+
+```ocaml
+type t = A | B of int | C of int * string [@@deriving json] [@@json.compact_variants]
+
+let json_a = to_json A
+(* "A" *)
+
+let json_b = to_json (B 42)
+(* ["B", 42] *)
+
+let json_c = to_json (C (1, "x"))
+(* ["C", 1, "x"] *)
+```
+
+This also works for polyvariant types:
+
+```ocaml
+type t = [`A | `B of int] [@@deriving json] [@@json.compact_variants]
+```
+
 #### `[@@deriving json_string]`: a shortcut for JSON string conversion
 
 For convenience, one can use `[@@deriving json_string]` to generate converters

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -107,8 +107,28 @@ module Of_json = struct
       [%e ensure_json_object ~loc x];
       [%e build_record ~loc derive t.rcd_fields x Fun.id]]
 
-  let derive_of_variant _derive t ~allow_any_constr body x =
+  let derive_of_variant _derive t ~allow_any_constr ?td body x =
     let loc = t.vrt_loc in
+    let not_array_error =
+      match allow_any_constr with
+      | Some allow_any_constr -> allow_any_constr x
+      | None ->
+          [%expr
+            Melange_json.of_json_error ~json:[%e x]
+              "expected a non empty JSON array"]
+    in
+    let string_branch =
+      if Option.fold ~none:false ~some:is_compact_variants td then
+        [%expr
+          if Stdlib.( = ) (Js.typeof [%e x]) "string" then (
+            let array = (Obj.magic [||] : Js.Json.t array) in
+            let len = 0 in
+            let tag = (Obj.magic [%e x] : string) in
+            ignore (array, len);
+            [%e body])
+          else [%e not_array_error]]
+      else not_array_error
+    in
     [%expr
       if Js.Array.isArray [%e x] then
         let array = (Obj.magic [%e x] : Js.Json.t array) in
@@ -127,24 +147,11 @@ module Of_json = struct
                     Melange_json.of_json_error ~json:[%e x]
                       "expected a non empty JSON array with element \
                        being a string"]]
-        else
-          [%e
-            match allow_any_constr with
-            | Some allow_any_constr -> allow_any_constr x
-            | None ->
-                [%expr
-                  Melange_json.of_json_error ~json:[%e x]
-                    "expected a non empty JSON array"]]
-      else
-        [%e
-          match allow_any_constr with
-          | Some allow_any_constr -> allow_any_constr x
-          | None ->
-              [%expr
-                Melange_json.of_json_error ~json:[%e x]
-                  "expected a non empty JSON array"]]]
+        else [%e not_array_error]
+      else [%e string_branch]]
 
-  let derive_of_variant_case derive make c ~allow_any_constr next =
+  let derive_of_variant_case ?td derive make c ~allow_any_constr next =
+    let compact = Option.fold ~none:false ~some:is_compact_variants td in
     match c with
     | Vcs_record (n, r) ->
         let loc = n.loc in
@@ -166,19 +173,25 @@ module Of_json = struct
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
-        [%expr
-          if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then
-            [%e
-              ensure_json_array_len ~loc ~allow_any_constr (arity + 1)
-                [%expr len] [%expr x]
-                ~else_:
-                  (if Stdlib.( = ) arity 0 then make None
-                   else
-                     make
-                       (Some
-                          (build_tuple ~loc derive 1 t.tpl_types
-                             [%expr array])))]
-          else [%e next]]
+        if compact && arity = 0 then
+          [%expr
+            if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then
+              [%e make None]
+            else [%e next]]
+        else
+          [%expr
+            if Stdlib.( = ) tag [%e estring ~loc:n.loc n.txt] then
+              [%e
+                ensure_json_array_len ~loc ~allow_any_constr (arity + 1)
+                  [%expr len] [%expr x]
+                  ~else_:
+                    (if Stdlib.( = ) arity 0 then make None
+                     else
+                       make
+                         (Some
+                            (build_tuple ~loc derive 1 t.tpl_types
+                               [%expr array])))]
+            else [%e next]]
 
   let is_allow_any_constr vcs =
     Ppx_deriving_json_common.vcs_attr_json_allow_any vcs
@@ -220,7 +233,8 @@ module To_json = struct
     let record = pexp_record ~loc fs None in
     as_json ~loc [%expr [%mel.obj [%e record]]]
 
-  let derive_of_variant_case derive c es =
+  let derive_of_variant_case ?td derive c es =
+    let compact = Option.fold ~none:false ~some:is_compact_variants td in
     match c with
     | Vcs_record (n, r) ->
         let loc = n.loc in
@@ -240,11 +254,15 @@ module To_json = struct
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
-        let tag =
-          [%expr (Obj.magic [%e estring ~loc:n.loc n.txt] : Js.Json.t)]
-        in
-        let es = List.map2 t.tpl_types es ~f:derive in
-        as_json ~loc (pexp_array ~loc (tag :: es))
+        let arity = List.length t.tpl_types in
+        if compact && arity = 0 then
+          as_json ~loc (estring ~loc:n.loc n.txt)
+        else
+          let tag =
+            [%expr (Obj.magic [%e estring ~loc:n.loc n.txt] : Js.Json.t)]
+          in
+          let es = List.map2 t.tpl_types es ~f:derive in
+          as_json ~loc (pexp_array ~loc (tag :: es))
 
   let deriving : Ppx_deriving_tools.deriving =
     deriving_to () ~name:"to_json"

--- a/ppx/native/common/ppx_deriving_json_common.ml
+++ b/ppx/native/common/ppx_deriving_json_common.ml
@@ -74,6 +74,16 @@ let ld_attr_json_drop_default =
        Ast_pattern.(pstr nil)
        ())
 
+let td_attr_json_compact_variants =
+  Attribute.get
+    (Attribute.declare "json.compact_variants"
+       Attribute.Context.type_declaration
+       Ast_pattern.(pstr nil)
+       ())
+
+let is_compact_variants td =
+  Option.is_some (td_attr_json_compact_variants td)
+
 let ld_attr_default ld =
   match ld_attr_json_default ld with
   | Some e -> Some e

--- a/ppx/native/common/ppx_deriving_tools.ml
+++ b/ppx/native/common/ppx_deriving_tools.ml
@@ -248,8 +248,8 @@ module Schema = struct
           not_supported "variant types" ~loc
 
       method derive_of_polyvariant :
-          core_type -> row_field list -> expression -> expression =
-        fun t _ _ ->
+          ?td:type_declaration -> core_type -> row_field list -> expression -> expression =
+        fun ?td:_ t _ _ ->
           let loc = t.ptyp_loc in
           not_supported "polyvariant types" ~loc
 
@@ -322,6 +322,9 @@ module Schema = struct
         let x = [%expr x] in
         let expr =
           match repr_type_declaration td with
+          | `Ptype_core_type ({ ptyp_desc = Ptyp_variant (fs, _, _); _ } as t)
+            ->
+              self#derive_of_polyvariant ~td t fs x
           | `Ptype_core_type t -> self#derive_of_core_type t x
           | `Ptype_variant ctors -> self#derive_of_variant td ctors x
           | `Ptype_record fs -> self#derive_of_record td fs x
@@ -426,13 +429,31 @@ module Conv = struct
     | Vrt_ctx_variant of type_declaration
     | Vrt_ctx_polyvariant of core_type
 
+  type derive_of_core_type = core_type -> expression -> expression
+
   let repr_polyvariant_cases cs =
     List.rev cs |> List.map ~f:(fun c -> c, Schema.repr_row_field c)
 
   let repr_variant_cases cs = List.rev cs
 
   let deriving_of ~name ~of_t ~is_allow_any_constr ~derive_of_tuple
-      ~derive_of_record ~derive_of_variant ~derive_of_variant_case () =
+      ~derive_of_record
+      ~(derive_of_variant :
+         derive_of_core_type ->
+         variant ->
+         allow_any_constr:(expression -> expression) option ->
+         ?td:type_declaration ->
+         expression ->
+         expression ->
+         expression)
+      ~(derive_of_variant_case :
+         ?td:type_declaration ->
+         derive_of_core_type ->
+         (expression option -> expression) ->
+         variant_case ->
+         allow_any_constr:(expression -> expression) option ->
+         expression ->
+         expression) () =
     (object (self)
        inherit Schema.deriving1
        method name = name
@@ -492,7 +513,7 @@ module Conv = struct
                      Vcs_record (n, t)
                    in
                    let next =
-                     derive_of_variant_case self#derive_of_core_type
+                     derive_of_variant_case ~td self#derive_of_core_type
                        (make n) t ~allow_any_constr next
                    in
                    next, t :: cases
@@ -504,7 +525,7 @@ module Conv = struct
                      Vcs_tuple (n, t)
                    in
                    let next =
-                     derive_of_variant_case self#derive_of_core_type
+                     derive_of_variant_case ~td self#derive_of_core_type
                        (make n) case ~allow_any_constr next
                    in
                    next, case :: cases)
@@ -517,9 +538,9 @@ module Conv = struct
            }
          in
          derive_of_variant self#derive_of_core_type t ~allow_any_constr
-           body x
+           ~td body x
 
-       method! derive_of_polyvariant t (cs : row_field list) x =
+       method! derive_of_polyvariant ?td t (cs : row_field list) x =
          let loc = t.ptyp_loc in
          let allow_any_constr =
            cs
@@ -567,8 +588,9 @@ module Conv = struct
                      Vcs_tuple (n, t)
                    in
                    let next =
-                     derive_of_variant_case self#derive_of_core_type make
-                       case ~allow_any_constr next
+                     derive_of_variant_case ?td
+                       self#derive_of_core_type make case ~allow_any_constr
+                       next
                    in
                    next, case :: cases
                | `Rinherit (n, ts) ->
@@ -595,12 +617,13 @@ module Conv = struct
            }
          in
          derive_of_variant self#derive_of_core_type t ~allow_any_constr
-           body x
+           ?td body x
      end
       :> deriving)
 
   let deriving_of_match ~name ~of_t ~cmp_sort_vcs ~derive_of_tuple
-      ~derive_of_record ~derive_of_variant_case () =
+      ~derive_of_record
+      ~(derive_of_variant_case : ?td:_ -> _ -> _ -> _ -> _) () =
     (object (self)
        inherit Schema.deriving1
        method name = name
@@ -654,7 +677,7 @@ module Conv = struct
                      in
                      Vcs_record (n, r)
                    in
-                   derive_of_variant_case self#derive_of_core_type
+                   derive_of_variant_case self#derive_of_core_type ~td
                      (make n) t
                    :: next
                | Pcstr_tuple ts ->
@@ -664,13 +687,13 @@ module Conv = struct
                      in
                      Vcs_tuple (n, t)
                    in
-                   derive_of_variant_case self#derive_of_core_type
+                   derive_of_variant_case self#derive_of_core_type ~td
                      (make n) t
                    :: next)
          in
          pexp_match ~loc x cases
 
-       method! derive_of_polyvariant t (cs : row_field list) x =
+       method! derive_of_polyvariant ?td t (cs : row_field list) x =
          let loc = t.ptyp_loc in
          let cases = repr_polyvariant_cases cs in
          let cases =
@@ -722,7 +745,7 @@ module Conv = struct
            List.fold_left ctors ~init:[ catch_all ]
              ~f:(fun next ((n : label loc), t) ->
                let make arg = pexp_variant ~loc:n.loc n.txt arg in
-               derive_of_variant_case self#derive_of_core_type make t
+               derive_of_variant_case ?td self#derive_of_core_type make t
                :: next)
          in
          pexp_match ~loc x cases
@@ -730,7 +753,12 @@ module Conv = struct
       :> deriving)
 
   let deriving_to ~name ~t_to ~derive_of_tuple ~derive_of_record
-      ~derive_of_variant_case () =
+      ~(derive_of_variant_case :
+         ?td:type_declaration ->
+         derive_of_core_type ->
+         variant_case ->
+         expression list ->
+         expression) () =
     (object (self)
        inherit Schema.deriving1
        method name = name
@@ -778,8 +806,8 @@ module Conv = struct
                       Vcs_record (n, t)
                     in
                     ctor_pat n (Some p)
-                    --> derive_of_variant_case self#derive_of_core_type t
-                          es
+                    --> derive_of_variant_case ~td
+                          self#derive_of_core_type t es
                 | Pcstr_tuple ts ->
                     let arity = List.length ts in
                     let t =
@@ -790,10 +818,10 @@ module Conv = struct
                     in
                     let p, es = gen_pat_tuple ~loc "x" arity in
                     ctor_pat n (if arity = 0 then None else Some p)
-                    --> derive_of_variant_case self#derive_of_core_type t
-                          es))
+                    --> derive_of_variant_case ~td
+                          self#derive_of_core_type t es))
 
-       method! derive_of_polyvariant t (cs : row_field list) x =
+       method! derive_of_polyvariant ?td t (cs : row_field list) x =
          let loc = t.ptyp_loc in
          let cases = repr_polyvariant_cases cs in
          let cases =
@@ -808,17 +836,16 @@ module Conv = struct
                      Vcs_tuple (n, t)
                    in
                    ppat_variant ~loc n.txt None
-                   --> derive_of_variant_case self#derive_of_core_type t
-                         []
+                   --> derive_of_variant_case ?td
+                         self#derive_of_core_type t []
                | `Rtag (n, ts) ->
                    let t =
                      { tpl_loc = loc; tpl_types = ts; tpl_ctx = ctx }
                    in
                    let ps, es = gen_pat_tuple ~loc "x" (List.length ts) in
                    ppat_variant ~loc n.txt (Some ps)
-                   --> derive_of_variant_case self#derive_of_core_type
-                         (Vcs_tuple (n, t))
-                         es
+                   --> derive_of_variant_case ?td
+                         self#derive_of_core_type (Vcs_tuple (n, t)) es
                | `Rinherit (n, ts) ->
                    [%pat? [%p ppat_type ~loc n] as x]
                    --> self#derive_of_core_type

--- a/ppx/native/common/ppx_deriving_tools.mli
+++ b/ppx/native/common/ppx_deriving_tools.mli
@@ -88,7 +88,8 @@ module Conv : sig
       expression list ->
       expression) ->
     derive_of_variant_case:
-      (derive_of_core_type ->
+      (?td:type_declaration ->
+      derive_of_core_type ->
       variant_case ->
       expression list ->
       expression) ->
@@ -111,11 +112,13 @@ module Conv : sig
       (derive_of_core_type ->
       variant ->
       allow_any_constr:(expression -> expression) option ->
+      ?td:type_declaration ->
       expression ->
       expression ->
       expression) ->
     derive_of_variant_case:
-      (derive_of_core_type ->
+      (?td:type_declaration ->
+      derive_of_core_type ->
       (expression option -> expression) ->
       variant_case ->
       allow_any_constr:(expression -> expression) option ->
@@ -137,7 +140,8 @@ module Conv : sig
       expression ->
       expression) ->
     derive_of_variant_case:
-      (derive_of_core_type ->
+      (?td:type_declaration ->
+      derive_of_core_type ->
       (expression option -> expression) ->
       variant_case ->
       case) ->
@@ -205,7 +209,7 @@ class virtual deriving1 : object
   (** ESSENTIAL METHODS *)
 
   method derive_of_polyvariant :
-    core_type -> row_field list -> expression -> expression
+    ?td:type_declaration -> core_type -> row_field list -> expression -> expression
 
   method derive_of_record :
     type_declaration -> label_declaration list -> expression -> expression

--- a/ppx/native/ppx_deriving_json_native.ml
+++ b/ppx/native/ppx_deriving_json_native.ml
@@ -131,7 +131,8 @@ module Of_json = struct
                 [%e estring ~loc (sprintf "expected a JSON object")]];
       ]
 
-  let derive_of_variant_case derive make vcs =
+  let derive_of_variant_case ?td derive make vcs =
+    let compact = Option.fold ~none:false ~some:is_compact_variants td in
     match vcs with
     | Vcs_tuple (n, t) when vcs_attr_json_allow_any t.tpl_ctx ->
         let loc = n.loc in
@@ -140,7 +141,9 @@ module Of_json = struct
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
         let arity = List.length t.tpl_types in
-        if arity = 0 then
+        if compact && arity = 0 then
+          [%pat? `String [%p pstring ~loc:n.loc n.txt]] --> make None
+        else if arity = 0 then
           [%pat? `List [ `String [%p pstring ~loc:n.loc n.txt] ]]
           --> make None
         else
@@ -218,7 +221,8 @@ module To_json = struct
         (let [%p pbnds] = [] in
          [%e e])]
 
-  let derive_of_variant_case derive vcs es =
+  let derive_of_variant_case ?td derive vcs es =
+    let compact = Option.fold ~none:false ~some:is_compact_variants td in
     match vcs with
     | Vcs_tuple (_n, t) when vcs_attr_json_allow_any t.tpl_ctx -> (
         match es with
@@ -230,10 +234,14 @@ module To_json = struct
     | Vcs_tuple (n, t) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.tpl_ctx) in
-        [%expr
-          `List
-            (`String [%e estring ~loc:n.loc n.txt]
-            :: [%e elist ~loc (List.map2 t.tpl_types es ~f:derive)])]
+        let arity = List.length t.tpl_types in
+        if compact && arity = 0 then
+          [%expr `String [%e estring ~loc:n.loc n.txt]]
+        else
+          [%expr
+            `List
+              (`String [%e estring ~loc:n.loc n.txt]
+              :: [%e elist ~loc (List.map2 t.tpl_types es ~f:derive)])]
     | Vcs_record (n, t) ->
         let loc = n.loc in
         let n = Option.value ~default:n (vcs_attr_json_name t.rcd_ctx) in

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -26,6 +26,8 @@ type array_list = { a: int array; b: int list} [@@deriving json]
 type json = Melange_json.t
 type of_json = C : string * (json -> 'a) * ('a -> json) * 'a -> of_json
 type color = Red | Green | Blue [@@deriving json]
+type compact_variant = Compact_variant | Compact_variant_of_int of int [@@deriving json] [@@json.compact_variants]
+type compact_polyvariant = [`Compact_polyvariant | `Compact_polyvariant_of_int of int] [@@deriving json] [@@json.compact_variants]
 
 type shape = 
   | Circle of float  (* radius *)
@@ -33,6 +35,10 @@ type shape =
   | Point of { x: float; y: float } [@@deriving json]
 
 let of_json_cases = [
+  C ({|"Compact_variant"|}, compact_variant_of_json, compact_variant_to_json, (Compact_variant : compact_variant));
+  C ({|["Compact_variant_of_int",42]|}, compact_variant_of_json, compact_variant_to_json, (Compact_variant_of_int 42 : compact_variant));
+  C ({|"Compact_polyvariant"|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant : compact_polyvariant));
+  C ({|["Compact_polyvariant_of_int",42]|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant_of_int 42 : compact_polyvariant));
   C ({|1|}, user_of_json, user_to_json, 1);
   C ({|"9223372036854775807"|}, userid_of_json, userid_to_json, 9223372036854775807L);
   C ({|1.1|}, floaty_of_json, floaty_to_json, 1.1);

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -7,6 +7,7 @@
   >  (name lib)
   >  (modes melange)
   >  (modules example example_json_string main)
+  >  (libraries melange-json)
   >  (flags :standard -w -20-37-69 -open Melange_json.Primitives)
   >  (preprocess (pps melange.ppx melange-json.ppx)))
   > (melange.emit
@@ -27,6 +28,14 @@
 
   $ node ./_build/default/output/main.js
   *** json deriver tests ***
+  JSON    DATA: "Compact_variant"
+  JSON REPRINT: "Compact_variant"
+  JSON    DATA: ["Compact_variant_of_int",42]
+  JSON REPRINT: ["Compact_variant_of_int",42]
+  JSON    DATA: "Compact_polyvariant"
+  JSON REPRINT: "Compact_polyvariant"
+  JSON    DATA: ["Compact_polyvariant_of_int",42]
+  JSON REPRINT: ["Compact_polyvariant_of_int",42]
   JSON    DATA: 1
   JSON REPRINT: 1
   JSON    DATA: "9223372036854775807"

--- a/ppx/test/ppx_deriving_json_js_variants.e2e.t
+++ b/ppx/test/ppx_deriving_json_js_variants.e2e.t
@@ -7,6 +7,7 @@
   >  (name lib)
   >  (modes melange)
   >  (modules main)
+  >  (libraries melange-json)
   >  (flags :standard -w -20-37-69)
   >  (preprocess (pps melange.ppx melange-json.ppx)))
   > (melange.emit

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -17,6 +17,14 @@
   $ dune build ./main.exe
 
   $ dune exec ./main.exe
+  JSON    DATA: "Compact_variant"
+  JSON REPRINT: "Compact_variant"
+  JSON    DATA: ["Compact_variant_of_int",42]
+  JSON REPRINT: ["Compact_variant_of_int",42]
+  JSON    DATA: "Compact_polyvariant"
+  JSON REPRINT: "Compact_polyvariant"
+  JSON    DATA: ["Compact_polyvariant_of_int",42]
+  JSON REPRINT: ["Compact_polyvariant_of_int",42]
   JSON    DATA: 1
   JSON REPRINT: 1
   JSON    DATA: "9223372036854775807"

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -855,6 +855,48 @@
   end [@@ocaml.doc "@inline"] [@@merlin.hide]
 
   $ cat <<"EOF" | run
+  > type compact_variant = A | B of int [@@deriving json] [@@json.compact_variants]
+  > EOF
+  type compact_variant = A | B of int
+  [@@deriving json] [@@json.compact_variants]
+  
+  include struct
+    let _ = fun (_ : compact_variant) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec compact_variant_of_json =
+      (fun x ->
+         match x with
+         | `String "A" -> A
+         | `List [ `String "B"; x_0 ] -> B (int_of_json x_0)
+         | _ ->
+             Melange_json.of_json_error ~json:x
+               "expected [\"A\"] or [\"B\", _]"
+        : Yojson.Basic.t -> compact_variant)
+  
+    let _ = compact_variant_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec compact_variant_to_json =
+      (fun x ->
+         match x with
+         | A -> `String "A"
+         | B x_0 -> `List [ `String "B"; int_to_json x_0 ]
+        : compact_variant -> Yojson.Basic.t)
+  
+    let _ = compact_variant_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+
+
+
+
+
+
+
+  $ cat <<"EOF" | run
   > type drop_default_option = { a: int; b_opt: int option; [@option] [@json.drop_default] } [@@deriving json]
   > EOF
   type drop_default_option = {

--- a/ppx/test/run.sh
+++ b/ppx/test/run.sh
@@ -13,6 +13,7 @@ echo '
  (name lib)
  (modes melange)
  (modules main_js)
+ (libraries melange-json)
  (flags :standard -w -20-37-69 -open Melange_json.Primitives)
  (preprocess (pps melange.ppx melange-json.ppx)))
 (melange.emit


### PR DESCRIPTION
## Summary

Adds support for `[@@json.compact_variants]` on both regular variant and polyvariant types.

This attribute changes the JSON encoding to a compact form:
- Constructors **without arguments** are encoded as plain JSON strings: `"A"`
- Constructors **with arguments** are encoded as JSON arrays: `["B", arg1, ...]`

```ocaml
type t = A | B of int [@@deriving json] [@@json.compact_variants]

(* A   →  "A"       *)
(* B 1 →  ["B", 1]  *)

type p = [`A | `B of int] [@@deriving json] [@@json.compact_variants]
```

This was previously only supported for regular variants. This PR extends the same behaviour to polyvariants on both the Melange (JS) and native PPX backends.

## Changes

- `ppx/native/common/ppx_deriving_tools.ml(i)` — thread optional `?td` through `derive_of_polyvariant` / `derive_of_variant_case` so the `compact_variants` attribute can be checked when generating polyvariant decoders/encoders
- `ppx/native/common/ppx_deriving_json_common.ml` — expose `is_compact_variants` helper
- `ppx/native/ppx_deriving_json_native.ml` — pass `~td` when deriving polyvariants
- `ppx/browser/ppx_deriving_json_js.ml` — same wiring for the JS backend; decoder now accepts a plain string branch when `compact_variants` is set
