### PR TITLE
Respect the `[@json.name "..."]` attribute in `of_json` errors.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- PPX: Respect the `[@json.name "..."]` attribute in `of_json` error
+  messages.
 - **[breaking]** PPX: Ignore extra JSON object fields by default in the native
   PPX, matching the Melange PPX. Add `[@json.disallow_extra_fields]` for
   records and inline records that should reject unknown keys.

--- a/ppx/native/common/ppx_deriving_json_common.ml
+++ b/ppx/native/common/ppx_deriving_json_common.ml
@@ -11,17 +11,9 @@ let get_of_variant ?mark_as_seen ~variant ~polyvariant = function
   | Vrt_ctx_variant ctx -> Attribute.get ?mark_as_seen variant ctx
   | Vrt_ctx_polyvariant ctx -> Attribute.get ?mark_as_seen polyvariant ctx
 
-let attr_json_name ctx =
-  Attribute.declare "json.name" ctx
-    Ast_pattern.(single_expr_payload (estring __'))
-    (fun x -> x)
-
 let vcs_attr_json_name =
-  let variant =
-    attr_json_name Attribute.Context.constructor_declaration
-  in
-  let polyvariant = attr_json_name Attribute.Context.rtag in
-  get_of_variant_case ~variant ~polyvariant
+  get_of_variant_case ~variant:Ppx_deriving_tools.attr_json_name_cd
+    ~polyvariant:Ppx_deriving_tools.attr_json_name_rtag
 
 let attr_json_allow_any ctx = Attribute.declare_flag "json.allow_any" ctx
 

--- a/ppx/native/common/ppx_deriving_tools.ml
+++ b/ppx/native/common/ppx_deriving_tools.ml
@@ -390,9 +390,22 @@ module Schema = struct
     end
 end
 
+let attr_json_name ctx =
+  Attribute.declare "json.name" ctx
+    Ast_pattern.(single_expr_payload (estring __'))
+    (fun x -> x)
+
+let attr_json_name_cd =
+  attr_json_name Attribute.Context.constructor_declaration
+
+let attr_json_name_rtag = attr_json_name Attribute.Context.rtag
+
 let rec get_variant_names ?(compact = false) ~loc c =
   match Schema.repr_row_field c with
   | `Rtag (name, ts) ->
+      let name =
+        Option.value ~default:name (Attribute.get attr_json_name_rtag c)
+      in
       [
         (if compact && ts = [] then Printf.sprintf {|"%s"|} name.txt
          else
@@ -407,7 +420,9 @@ let rec get_variant_names ?(compact = false) ~loc c =
 
 let get_constructor_names ?(compact = false) cs =
   List.map cs ~f:(fun c ->
-      let name = c.pcd_name in
+      let name =
+        Option.value ~default:c.pcd_name (Attribute.get attr_json_name_cd c)
+      in
       match c.pcd_args with
       | Pcstr_record _fs -> Printf.sprintf {|["%s", { _ }]|} name.txt
       | Pcstr_tuple [] when compact -> Printf.sprintf {|"%s"|} name.txt

--- a/ppx/native/common/ppx_deriving_tools.mli
+++ b/ppx/native/common/ppx_deriving_tools.mli
@@ -154,6 +154,13 @@ module Conv : sig
       matching. *)
 end
 
+val attr_json_name_cd :
+  (constructor_declaration, label loc) Attribute.t
+(** The [[@json.name "..."]] attribute on a variant constructor. *)
+
+val attr_json_name_rtag : (row_field, label loc) Attribute.t
+(** The [[@json.name "..."]] attribute on a polymorphic variant tag. *)
+
 val not_supported : loc:location -> string -> 'a
 (** [not_supported what] terminates ppx with an error message telling
     [what] unsupported. *)

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -869,7 +869,7 @@
                  else B
                else
                  Melange_json.of_json_error ~json:x
-                   "expected [\"B\"] or [\"A\"]"
+                   "expected [\"b_aliased\"] or [\"A\"]"
              else
                Melange_json.of_json_error ~json:x
                  "expected a non empty JSON array with element being a \
@@ -929,7 +929,7 @@
                  else `b
                else
                  Melange_json.of_json_unexpected_variant ~json:x
-                   "expected [\"a\"] or [\"b\"]"
+                   "expected [\"A_aliased\"] or [\"b\"]"
              else
                Melange_json.of_json_error ~json:x
                  "expected a non empty JSON array with element being a \

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -646,7 +646,7 @@
          | `List (`String "b_aliased" :: []) -> B
          | _ ->
              Melange_json.of_json_error ~json:x
-               "expected [\"A\"] or [\"B\"]"
+               "expected [\"A\"] or [\"b_aliased\"]"
         : Yojson.Basic.t -> evar)
   
     let _ = evar_of_json
@@ -680,7 +680,7 @@
          | `List (`String "b" :: []) -> `b
          | x ->
              Melange_json.of_json_unexpected_variant ~json:x
-               "expected [\"a\"] or [\"b\"]"
+               "expected [\"A_aliased\"] or [\"b\"]"
         : Yojson.Basic.t -> epoly)
   
     let _ = epoly_of_json


### PR DESCRIPTION
## What

When a variant constructor is renamed with `[@json.name "..."]` (or `[@name "..."]`), the `of_json` decoder accepts the renamed tag, but the generated "expected ..." error message still lists the original OCaml constructor name — naming a tag the decoder would actually reject.
This PR makes the error message use the renamed tag, for both variants and polyvar.

Sample
```ocaml                         
type t =
  | A
  | Different_named [@name "different_name"]
[@@deriving json]
```
Before:
```
expected ["A"] or ["Different_named"] but got ["Bar"]
```
After
```
expected ["A"] or ["different_name"] but got ["Bar"]
```
Adapted from the upstream fix in melange-community/melange-json#51.
