### PR TITLE
Use len as expression instead of an expected value on variant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
-- Fix: remove the duplicated runtime deps from the `ppx` libraries.
+- Fix: use the `len` value as expression on the variant case function to avoid
+  expected "named" value to be declared on the function.
+- Fix: remove the duplicated runtime deps from the ppx libraries.
 - Move the JSON Schema runtime into the main packages, at `Jsonkit.Jsonschema`.
   It is the same API under a new path, on both backends, so sources shared
   between a native and a Melange build need no per-backend conditionals. The

--- a/ppx/browser/ppx_deriving_json_js.ml
+++ b/ppx/browser/ppx_deriving_json_js.ml
@@ -186,13 +186,13 @@ module Of_json = struct
   let build_unknown_variant_case_record ~loc ~tag ~array ~len =
     [%expr
       let payload =
-        if Stdlib.( = ) len 0 then Stdlib.Option.None
-        else if Stdlib.( = ) len 1 then Stdlib.Option.Some []
+        if Stdlib.( = ) [%e len] 0 then Stdlib.Option.None
+        else if Stdlib.( = ) [%e len] 1 then Stdlib.Option.Some []
         else
           let rest =
             Stdlib.Array.sub [%e array] 1 (Stdlib.( - ) [%e len] 1)
             |> Stdlib.Array.to_list
-            |> Stdlib.List.map (fun j -> (Obj.magic j : Jsonkit.t))
+            |> Stdlib.List.map (fun j -> Obj.magic j)
           in
           Stdlib.Option.Some rest
       in
@@ -432,9 +432,7 @@ module To_json = struct
       | Stdlib.Option.Some xs ->
           let head = (Obj.magic ([%e tag] : string) : Js.Json.t) in
           let rest =
-            Stdlib.List.map
-              (fun (j : Jsonkit.t) -> (Obj.magic j : Js.Json.t))
-              xs
+            Stdlib.List.map (fun (j : Jsonkit.t) -> Obj.magic j) xs
           in
           (Obj.magic
              (Stdlib.Array.of_list (head :: rest) : Js.Json.t array)

--- a/ppx/test/example.ml
+++ b/ppx/test/example.ml
@@ -60,8 +60,11 @@ type of_json = C : string * (json -> 'a) * ('a -> json) * 'a -> of_json
 type color = Red | Green | Blue [@@deriving json]
 type compact_variant = Compact_variant | Compact_variant_of_int of int [@@deriving json] [@@json.compact_variants]
 type compact_polyvariant = [`Compact_polyvariant | `Compact_polyvariant_of_int of int] [@@deriving json] [@@json.compact_variants]
+type catch_all_variant = Catch_all_variant | Catch_all_variant_of_int of int | Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all] [@@deriving json] [@@json.compact_variants]
+type catch_all_polyvariant = [`Catch_all_polyvariant | `Catch_all_polyvariant_of_int of int | `Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all]] [@@deriving json] [@@json.compact_variants]
+type catch_all_noncompact = Catch_all_noncompact_of_int of int | Catch_all_noncompact_other of Jsonkit.unknown_variant_case [@json.catch_all] [@@deriving json]
 
-type shape = 
+type shape =
   | Circle of float  (* radius *)
   | Rectangle of float * float  (* width * height *)
   | Point of { x: float; y: float } [@@deriving json]
@@ -73,6 +76,19 @@ let of_json_cases = [
   C ({|"Compact_polyvariant"|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant : compact_polyvariant));
   C ({|["Compact_polyvariant"]|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant : compact_polyvariant));
   C ({|["Compact_polyvariant_of_int",42]|}, compact_polyvariant_of_json, compact_polyvariant_to_json, (`Compact_polyvariant_of_int 42 : compact_polyvariant));
+  C ({|"Catch_all_variant"|}, catch_all_variant_of_json, catch_all_variant_to_json, (Catch_all_variant : catch_all_variant));
+  C ({|["Catch_all_variant_of_int",42]|}, catch_all_variant_of_json, catch_all_variant_to_json, (Catch_all_variant_of_int 42 : catch_all_variant));
+  C ({|"Unknown"|}, catch_all_variant_of_json, catch_all_variant_to_json, (Catch_all_other { Jsonkit.tag = "Unknown"; payload = None } : catch_all_variant));
+  C ({|["Unknown"]|}, catch_all_variant_of_json, catch_all_variant_to_json, (Catch_all_other { Jsonkit.tag = "Unknown"; payload = Some [] } : catch_all_variant));
+  C ({|["Unknown",1,"x"]|}, catch_all_variant_of_json, catch_all_variant_to_json, (Catch_all_other { Jsonkit.tag = "Unknown"; payload = Some [int_to_json 1; string_to_json "x"] } : catch_all_variant));
+  C ({|"Catch_all_polyvariant"|}, catch_all_polyvariant_of_json, catch_all_polyvariant_to_json, (`Catch_all_polyvariant : catch_all_polyvariant));
+  C ({|["Catch_all_polyvariant_of_int",42]|}, catch_all_polyvariant_of_json, catch_all_polyvariant_to_json, (`Catch_all_polyvariant_of_int 42 : catch_all_polyvariant));
+  C ({|"Unknown"|}, catch_all_polyvariant_of_json, catch_all_polyvariant_to_json, (`Catch_all_other { Jsonkit.tag = "Unknown"; payload = None } : catch_all_polyvariant));
+  C ({|["Unknown"]|}, catch_all_polyvariant_of_json, catch_all_polyvariant_to_json, (`Catch_all_other { Jsonkit.tag = "Unknown"; payload = Some [] } : catch_all_polyvariant));
+  C ({|["Unknown",1,"x"]|}, catch_all_polyvariant_of_json, catch_all_polyvariant_to_json, (`Catch_all_other { Jsonkit.tag = "Unknown"; payload = Some [int_to_json 1; string_to_json "x"] } : catch_all_polyvariant));
+  C ({|["Catch_all_noncompact_of_int",42]|}, catch_all_noncompact_of_json, catch_all_noncompact_to_json, (Catch_all_noncompact_of_int 42 : catch_all_noncompact));
+  C ({|["Unknown"]|}, catch_all_noncompact_of_json, catch_all_noncompact_to_json, (Catch_all_noncompact_other { Jsonkit.tag = "Unknown"; payload = Some [] } : catch_all_noncompact));
+  C ({|["Unknown",{"a":1}]|}, catch_all_noncompact_of_json, catch_all_noncompact_to_json, (Catch_all_noncompact_other { Jsonkit.tag = "Unknown"; payload = Some [Jsonkit.of_string {|{"a":1}|}] } : catch_all_noncompact));
   C ({|1|}, user_of_json, user_to_json, 1);
   C ({|"9223372036854775807"|}, userid_of_json, userid_to_json, 9223372036854775807L);
   C ({|1.1|}, floaty_of_json, floaty_to_json, 1.1);
@@ -150,11 +166,11 @@ type must_be_array_3 = (int * int * int) [@@deriving json]
 let error_cases = [
   (* Should fail with "expected a JSON object" *)
   C ({|42|}, must_be_object_of_json, must_be_object_to_json, {field=1});
-  
+
   (* Should fail with "expected a JSON array of length 2" *)
   C ({|[1]|}, must_be_array_2_of_json, must_be_array_2_to_json, (1, 2));
   C ({|[1,2,3]|}, must_be_array_2_of_json, must_be_array_2_to_json, (1, 2));
-  
+
   (* Should fail with "expected a JSON array of length 3" *)
   C ({|[1,2]|}, must_be_array_3_of_json, must_be_array_3_to_json, (1, 2, 3));
   C ({|[1,2,3,4]|}, must_be_array_3_of_json, must_be_array_3_to_json, (1, 2, 3));

--- a/ppx/test/ppx_deriving_json_js.e2e.t
+++ b/ppx/test/ppx_deriving_json_js.e2e.t
@@ -40,6 +40,32 @@
   JSON REPRINT: "Compact_polyvariant"
   JSON    DATA: ["Compact_polyvariant_of_int",42]
   JSON REPRINT: ["Compact_polyvariant_of_int",42]
+  JSON    DATA: "Catch_all_variant"
+  JSON REPRINT: "Catch_all_variant"
+  JSON    DATA: ["Catch_all_variant_of_int",42]
+  JSON REPRINT: ["Catch_all_variant_of_int",42]
+  JSON    DATA: "Unknown"
+  JSON REPRINT: "Unknown"
+  JSON    DATA: ["Unknown"]
+  JSON REPRINT: ["Unknown"]
+  JSON    DATA: ["Unknown",1,"x"]
+  JSON REPRINT: ["Unknown",1,"x"]
+  JSON    DATA: "Catch_all_polyvariant"
+  JSON REPRINT: "Catch_all_polyvariant"
+  JSON    DATA: ["Catch_all_polyvariant_of_int",42]
+  JSON REPRINT: ["Catch_all_polyvariant_of_int",42]
+  JSON    DATA: "Unknown"
+  JSON REPRINT: "Unknown"
+  JSON    DATA: ["Unknown"]
+  JSON REPRINT: ["Unknown"]
+  JSON    DATA: ["Unknown",1,"x"]
+  JSON REPRINT: ["Unknown",1,"x"]
+  JSON    DATA: ["Catch_all_noncompact_of_int",42]
+  JSON REPRINT: ["Catch_all_noncompact_of_int",42]
+  JSON    DATA: ["Unknown"]
+  JSON REPRINT: ["Unknown"]
+  JSON    DATA: ["Unknown",{"a":1}]
+  JSON REPRINT: ["Unknown",{"a":1}]
   JSON    DATA: 1
   JSON REPRINT: 1
   JSON    DATA: "9223372036854775807"

--- a/ppx/test/ppx_deriving_json_js.t
+++ b/ppx/test/ppx_deriving_json_js.t
@@ -1525,6 +1525,323 @@
 Test for polyvariant without own cases (only inherits) - should not produce unused variable warning for `tag`:
 
   $ cat <<"EOF" | run
+  > type catch_all_variant = Catch_all_variant | Catch_all_variant_of_int of int | Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all] [@@deriving json] [@@json.compact_variants]
+  > EOF
+  type catch_all_variant =
+    | Catch_all_variant
+    | Catch_all_variant_of_int of int
+    | Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all]
+  [@@deriving json] [@@json.compact_variants]
+  
+  include struct
+    let _ = fun (_ : catch_all_variant) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_variant_of_json =
+      (fun x ->
+         if Js.Array.isArray x then
+           let array = (Obj.magic x : Js.Json.t array) in
+           let len = Js.Array.length array in
+           if Stdlib.( > ) len 0 then
+             let tag = Js.Array.unsafe_get array 0 in
+             if Stdlib.( = ) (Js.typeof tag) "string" then
+               if Stdlib.( = ) (Obj.magic tag : string) "Catch_all_variant"
+               then Catch_all_variant
+               else if
+                 Stdlib.( = )
+                   (Obj.magic tag : string)
+                   "Catch_all_variant_of_int"
+               then
+                 if Stdlib.( <> ) len 2 then
+                   Jsonkit.of_json_error ~json:x
+                     "expected a JSON array of length 2"
+                 else
+                   Catch_all_variant_of_int
+                     (int_of_json (Js.Array.unsafe_get array 1))
+               else
+                 Catch_all_other
+                   (let payload =
+                      if Stdlib.( = ) len 0 then Stdlib.Option.None
+                      else if Stdlib.( = ) len 1 then Stdlib.Option.Some []
+                      else
+                        let rest =
+                          Stdlib.Array.sub array 1 (Stdlib.( - ) len 1)
+                          |> Stdlib.Array.to_list
+                          |> Stdlib.List.map (fun j -> Obj.magic j)
+                        in
+                        Stdlib.Option.Some rest
+                    in
+                    ({ tag = (Obj.magic tag : string); payload }
+                      : Jsonkit.unknown_variant_case))
+             else
+               Jsonkit.of_json_error ~json:x
+                 "expected a non empty JSON array with element being a \
+                  string"
+           else
+             Jsonkit.of_json_error ~json:x "expected a non empty JSON array"
+         else if Stdlib.( = ) (Js.typeof x) "string" then
+           if Stdlib.( = ) (Obj.magic x : string) "Catch_all_variant" then
+             Catch_all_variant
+           else
+             Catch_all_other
+               (let payload =
+                  if Stdlib.( = ) 0 0 then Stdlib.Option.None
+                  else if Stdlib.( = ) 0 1 then Stdlib.Option.Some []
+                  else
+                    let rest =
+                      Stdlib.Array.sub
+                        (Obj.magic [||] : Js.Json.t array)
+                        1 (Stdlib.( - ) 0 1)
+                      |> Stdlib.Array.to_list
+                      |> Stdlib.List.map (fun j -> Obj.magic j)
+                    in
+                    Stdlib.Option.Some rest
+                in
+                ({ tag = (Obj.magic x : string); payload }
+                  : Jsonkit.unknown_variant_case))
+         else
+           Jsonkit.of_json_error ~json:x "expected a non empty JSON array"
+        : Js.Json.t -> catch_all_variant)
+  
+    let _ = catch_all_variant_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_variant_to_json =
+      (fun x ->
+         match x with
+         | Catch_all_variant -> (Obj.magic "Catch_all_variant" : Js.Json.t)
+         | Catch_all_variant_of_int x_0 ->
+             (Obj.magic
+                [|
+                  (Obj.magic "Catch_all_variant_of_int" : Js.Json.t);
+                  int_to_json x_0;
+                |]
+               : Js.Json.t)
+         | Catch_all_other x_0 -> (
+             match x_0.payload with
+             | Stdlib.Option.None ->
+                 (Obj.magic (x_0.tag : string) : Js.Json.t)
+             | Stdlib.Option.Some xs ->
+                 let head = (Obj.magic (x_0.tag : string) : Js.Json.t) in
+                 let rest =
+                   Stdlib.List.map (fun (j : Jsonkit.t) -> Obj.magic j) xs
+                 in
+                 (Obj.magic
+                    (Stdlib.Array.of_list (head :: rest) : Js.Json.t array)
+                   : Js.Json.t))
+        : catch_all_variant -> Js.Json.t)
+  
+    let _ = catch_all_variant_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
+  > type catch_all_polyvariant = [`Catch_all_polyvariant | `Catch_all_polyvariant_of_int of int | `Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all]] [@@deriving json] [@@json.compact_variants]
+  > EOF
+  type catch_all_polyvariant =
+    [ `Catch_all_polyvariant
+    | `Catch_all_polyvariant_of_int of int
+    | `Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all] ]
+  [@@deriving json] [@@json.compact_variants]
+  
+  include struct
+    let _ = fun (_ : catch_all_polyvariant) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_polyvariant_of_json =
+      (fun x ->
+         if Js.Array.isArray x then
+           let array = (Obj.magic x : Js.Json.t array) in
+           let len = Js.Array.length array in
+           if Stdlib.( > ) len 0 then
+             let tag = Js.Array.unsafe_get array 0 in
+             if Stdlib.( = ) (Js.typeof tag) "string" then
+               if
+                 Stdlib.( = )
+                   (Obj.magic tag : string)
+                   "Catch_all_polyvariant"
+               then `Catch_all_polyvariant
+               else if
+                 Stdlib.( = )
+                   (Obj.magic tag : string)
+                   "Catch_all_polyvariant_of_int"
+               then
+                 if Stdlib.( <> ) len 2 then
+                   Jsonkit.of_json_error ~json:x
+                     "expected a JSON array of length 2"
+                 else
+                   `Catch_all_polyvariant_of_int
+                     (int_of_json (Js.Array.unsafe_get array 1))
+               else
+                 `Catch_all_other
+                   (let payload =
+                      if Stdlib.( = ) len 0 then Stdlib.Option.None
+                      else if Stdlib.( = ) len 1 then Stdlib.Option.Some []
+                      else
+                        let rest =
+                          Stdlib.Array.sub array 1 (Stdlib.( - ) len 1)
+                          |> Stdlib.Array.to_list
+                          |> Stdlib.List.map (fun j -> Obj.magic j)
+                        in
+                        Stdlib.Option.Some rest
+                    in
+                    ({ tag = (Obj.magic tag : string); payload }
+                      : Jsonkit.unknown_variant_case))
+             else
+               Jsonkit.of_json_error ~json:x
+                 "expected a non empty JSON array with element being a \
+                  string"
+           else
+             Jsonkit.of_json_error ~json:x "expected a non empty JSON array"
+         else if Stdlib.( = ) (Js.typeof x) "string" then
+           if Stdlib.( = ) (Obj.magic x : string) "Catch_all_polyvariant"
+           then `Catch_all_polyvariant
+           else
+             `Catch_all_other
+               (let payload =
+                  if Stdlib.( = ) 0 0 then Stdlib.Option.None
+                  else if Stdlib.( = ) 0 1 then Stdlib.Option.Some []
+                  else
+                    let rest =
+                      Stdlib.Array.sub
+                        (Obj.magic [||] : Js.Json.t array)
+                        1 (Stdlib.( - ) 0 1)
+                      |> Stdlib.Array.to_list
+                      |> Stdlib.List.map (fun j -> Obj.magic j)
+                    in
+                    Stdlib.Option.Some rest
+                in
+                ({ tag = (Obj.magic x : string); payload }
+                  : Jsonkit.unknown_variant_case))
+         else
+           Jsonkit.of_json_error ~json:x "expected a non empty JSON array"
+        : Js.Json.t -> catch_all_polyvariant)
+  
+    let _ = catch_all_polyvariant_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_polyvariant_to_json =
+      (fun x ->
+         match x with
+         | `Catch_all_polyvariant ->
+             (Obj.magic "Catch_all_polyvariant" : Js.Json.t)
+         | `Catch_all_polyvariant_of_int x_0 ->
+             (Obj.magic
+                [|
+                  (Obj.magic "Catch_all_polyvariant_of_int" : Js.Json.t);
+                  int_to_json x_0;
+                |]
+               : Js.Json.t)
+         | `Catch_all_other x_0 -> (
+             match x_0.payload with
+             | Stdlib.Option.None ->
+                 (Obj.magic (x_0.tag : string) : Js.Json.t)
+             | Stdlib.Option.Some xs ->
+                 let head = (Obj.magic (x_0.tag : string) : Js.Json.t) in
+                 let rest =
+                   Stdlib.List.map (fun (j : Jsonkit.t) -> Obj.magic j) xs
+                 in
+                 (Obj.magic
+                    (Stdlib.Array.of_list (head :: rest) : Js.Json.t array)
+                   : Js.Json.t))
+        : catch_all_polyvariant -> Js.Json.t)
+  
+    let _ = catch_all_polyvariant_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
+  > type catch_all_noncompact = Catch_all_noncompact_of_int of int | Catch_all_noncompact_other of Jsonkit.unknown_variant_case [@json.catch_all] [@@deriving json]
+  > EOF
+  type catch_all_noncompact =
+    | Catch_all_noncompact_of_int of int
+    | Catch_all_noncompact_other of Jsonkit.unknown_variant_case
+        [@json.catch_all]
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : catch_all_noncompact) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_noncompact_of_json =
+      (fun x ->
+         if Js.Array.isArray x then
+           let array = (Obj.magic x : Js.Json.t array) in
+           let len = Js.Array.length array in
+           if Stdlib.( > ) len 0 then
+             let tag = Js.Array.unsafe_get array 0 in
+             if Stdlib.( = ) (Js.typeof tag) "string" then
+               if
+                 Stdlib.( = )
+                   (Obj.magic tag : string)
+                   "Catch_all_noncompact_of_int"
+               then
+                 if Stdlib.( <> ) len 2 then
+                   Jsonkit.of_json_error ~json:x
+                     "expected a JSON array of length 2"
+                 else
+                   Catch_all_noncompact_of_int
+                     (int_of_json (Js.Array.unsafe_get array 1))
+               else
+                 Catch_all_noncompact_other
+                   (let payload =
+                      if Stdlib.( = ) len 0 then Stdlib.Option.None
+                      else if Stdlib.( = ) len 1 then Stdlib.Option.Some []
+                      else
+                        let rest =
+                          Stdlib.Array.sub array 1 (Stdlib.( - ) len 1)
+                          |> Stdlib.Array.to_list
+                          |> Stdlib.List.map (fun j -> Obj.magic j)
+                        in
+                        Stdlib.Option.Some rest
+                    in
+                    ({ tag = (Obj.magic tag : string); payload }
+                      : Jsonkit.unknown_variant_case))
+             else
+               Jsonkit.of_json_error ~json:x
+                 "expected a non empty JSON array with element being a \
+                  string"
+           else
+             Jsonkit.of_json_error ~json:x "expected a non empty JSON array"
+         else
+           Jsonkit.of_json_error ~json:x "expected a non empty JSON array"
+        : Js.Json.t -> catch_all_noncompact)
+  
+    let _ = catch_all_noncompact_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_noncompact_to_json =
+      (fun x ->
+         match x with
+         | Catch_all_noncompact_of_int x_0 ->
+             (Obj.magic
+                [|
+                  (Obj.magic "Catch_all_noncompact_of_int" : Js.Json.t);
+                  int_to_json x_0;
+                |]
+               : Js.Json.t)
+         | Catch_all_noncompact_other x_0 -> (
+             match x_0.payload with
+             | Stdlib.Option.None ->
+                 (Obj.magic (x_0.tag : string) : Js.Json.t)
+             | Stdlib.Option.Some xs ->
+                 let head = (Obj.magic (x_0.tag : string) : Js.Json.t) in
+                 let rest =
+                   Stdlib.List.map (fun (j : Jsonkit.t) -> Obj.magic j) xs
+                 in
+                 (Obj.magic
+                    (Stdlib.Array.of_list (head :: rest) : Js.Json.t array)
+                   : Js.Json.t))
+        : catch_all_noncompact -> Js.Json.t)
+  
+    let _ = catch_all_noncompact_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
   > type one = [ `C ] [@@deriving json]
   > type other = [ `C ] [@@deriving json]
   > type poly = [ one | other ] [@@deriving json]

--- a/ppx/test/ppx_deriving_json_native.e2e.t
+++ b/ppx/test/ppx_deriving_json_native.e2e.t
@@ -29,6 +29,32 @@
   JSON REPRINT: "Compact_polyvariant"
   JSON    DATA: ["Compact_polyvariant_of_int",42]
   JSON REPRINT: ["Compact_polyvariant_of_int",42]
+  JSON    DATA: "Catch_all_variant"
+  JSON REPRINT: "Catch_all_variant"
+  JSON    DATA: ["Catch_all_variant_of_int",42]
+  JSON REPRINT: ["Catch_all_variant_of_int",42]
+  JSON    DATA: "Unknown"
+  JSON REPRINT: "Unknown"
+  JSON    DATA: ["Unknown"]
+  JSON REPRINT: ["Unknown"]
+  JSON    DATA: ["Unknown",1,"x"]
+  JSON REPRINT: ["Unknown",1,"x"]
+  JSON    DATA: "Catch_all_polyvariant"
+  JSON REPRINT: "Catch_all_polyvariant"
+  JSON    DATA: ["Catch_all_polyvariant_of_int",42]
+  JSON REPRINT: ["Catch_all_polyvariant_of_int",42]
+  JSON    DATA: "Unknown"
+  JSON REPRINT: "Unknown"
+  JSON    DATA: ["Unknown"]
+  JSON REPRINT: ["Unknown"]
+  JSON    DATA: ["Unknown",1,"x"]
+  JSON REPRINT: ["Unknown",1,"x"]
+  JSON    DATA: ["Catch_all_noncompact_of_int",42]
+  JSON REPRINT: ["Catch_all_noncompact_of_int",42]
+  JSON    DATA: ["Unknown"]
+  JSON REPRINT: ["Unknown"]
+  JSON    DATA: ["Unknown",{"a":1}]
+  JSON REPRINT: ["Unknown",{"a":1}]
   JSON    DATA: 1
   JSON REPRINT: 1
   JSON    DATA: "9223372036854775807"

--- a/ppx/test/ppx_deriving_json_native.t
+++ b/ppx/test/ppx_deriving_json_native.t
@@ -877,6 +877,177 @@
 
 
   $ cat <<"EOF" | run
+  > type catch_all_variant = Catch_all_variant | Catch_all_variant_of_int of int | Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all] [@@deriving json] [@@json.compact_variants]
+  > EOF
+  type catch_all_variant =
+    | Catch_all_variant
+    | Catch_all_variant_of_int of int
+    | Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all]
+  [@@deriving json] [@@json.compact_variants]
+  
+  include struct
+    let _ = fun (_ : catch_all_variant) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_variant_of_json =
+      (fun x ->
+         match x with
+         | `String "Catch_all_variant"
+         | `List (`String "Catch_all_variant" :: []) ->
+             Catch_all_variant
+         | `List [ `String "Catch_all_variant_of_int"; x_0 ] ->
+             Catch_all_variant_of_int (int_of_json x_0)
+         | (`String _ | `List (`String _ :: _)) as v ->
+             let tag, payload =
+               match v with
+               | `String s -> s, Stdlib.Option.None
+               | `List (`String s :: payload) ->
+                   s, Stdlib.Option.Some payload
+               | _ -> assert false
+             in
+             Catch_all_other
+               ({ tag; payload } : Jsonkit.unknown_variant_case)
+         | _ ->
+             Jsonkit.of_json_error ~json:x
+               "expected \"Catch_all_variant\" or \
+                [\"Catch_all_variant_of_int\", _] or [\"Catch_all_other\", \
+                _]"
+        : Yojson.Basic.t -> catch_all_variant)
+  
+    let _ = catch_all_variant_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_variant_to_json =
+      (fun x ->
+         match x with
+         | Catch_all_variant -> `String "Catch_all_variant"
+         | Catch_all_variant_of_int x_0 ->
+             `List [ `String "Catch_all_variant_of_int"; int_to_json x_0 ]
+         | Catch_all_other x_0 -> (
+             match x_0.payload with
+             | Stdlib.Option.None -> `String x_0.tag
+             | Stdlib.Option.Some xs -> `List (`String x_0.tag :: xs))
+        : catch_all_variant -> Yojson.Basic.t)
+  
+    let _ = catch_all_variant_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
+  > type catch_all_polyvariant = [`Catch_all_polyvariant | `Catch_all_polyvariant_of_int of int | `Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all]] [@@deriving json] [@@json.compact_variants]
+  > EOF
+  type catch_all_polyvariant =
+    [ `Catch_all_polyvariant
+    | `Catch_all_polyvariant_of_int of int
+    | `Catch_all_other of Jsonkit.unknown_variant_case [@json.catch_all] ]
+  [@@deriving json] [@@json.compact_variants]
+  
+  include struct
+    let _ = fun (_ : catch_all_polyvariant) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_polyvariant_of_json =
+      (fun x ->
+         match x with
+         | `String "Catch_all_polyvariant"
+         | `List (`String "Catch_all_polyvariant" :: []) ->
+             `Catch_all_polyvariant
+         | `List [ `String "Catch_all_polyvariant_of_int"; x_0 ] ->
+             `Catch_all_polyvariant_of_int (int_of_json x_0)
+         | (`String _ | `List (`String _ :: _)) as v ->
+             let tag, payload =
+               match v with
+               | `String s -> s, Stdlib.Option.None
+               | `List (`String s :: payload) ->
+                   s, Stdlib.Option.Some payload
+               | _ -> assert false
+             in
+             `Catch_all_other
+               ({ tag; payload } : Jsonkit.unknown_variant_case)
+         | x ->
+             Jsonkit.of_json_unexpected_variant ~json:x
+               "expected \"Catch_all_polyvariant\" or \
+                [\"Catch_all_polyvariant_of_int\", _] or \
+                [\"Catch_all_other\", _]"
+        : Yojson.Basic.t -> catch_all_polyvariant)
+  
+    let _ = catch_all_polyvariant_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_polyvariant_to_json =
+      (fun x ->
+         match x with
+         | `Catch_all_polyvariant -> `String "Catch_all_polyvariant"
+         | `Catch_all_polyvariant_of_int x_0 ->
+             `List
+               [ `String "Catch_all_polyvariant_of_int"; int_to_json x_0 ]
+         | `Catch_all_other x_0 -> (
+             match x_0.payload with
+             | Stdlib.Option.None -> `String x_0.tag
+             | Stdlib.Option.Some xs -> `List (`String x_0.tag :: xs))
+        : catch_all_polyvariant -> Yojson.Basic.t)
+  
+    let _ = catch_all_polyvariant_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
+  > type catch_all_noncompact = Catch_all_noncompact_of_int of int | Catch_all_noncompact_other of Jsonkit.unknown_variant_case [@json.catch_all] [@@deriving json]
+  > EOF
+  type catch_all_noncompact =
+    | Catch_all_noncompact_of_int of int
+    | Catch_all_noncompact_other of Jsonkit.unknown_variant_case
+        [@json.catch_all]
+  [@@deriving json]
+  
+  include struct
+    let _ = fun (_ : catch_all_noncompact) -> ()
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_noncompact_of_json =
+      (fun x ->
+         match x with
+         | `List [ `String "Catch_all_noncompact_of_int"; x_0 ] ->
+             Catch_all_noncompact_of_int (int_of_json x_0)
+         | (`String _ | `List (`String _ :: _)) as v ->
+             let tag, payload =
+               match v with
+               | `String s -> s, Stdlib.Option.None
+               | `List (`String s :: payload) ->
+                   s, Stdlib.Option.Some payload
+               | _ -> assert false
+             in
+             Catch_all_noncompact_other
+               ({ tag; payload } : Jsonkit.unknown_variant_case)
+         | _ ->
+             Jsonkit.of_json_error ~json:x
+               "expected [\"Catch_all_noncompact_of_int\", _] or \
+                [\"Catch_all_noncompact_other\", _]"
+        : Yojson.Basic.t -> catch_all_noncompact)
+  
+    let _ = catch_all_noncompact_of_json
+  
+    [@@@ocaml.warning "-39-11-27"]
+  
+    let rec catch_all_noncompact_to_json =
+      (fun x ->
+         match x with
+         | Catch_all_noncompact_of_int x_0 ->
+             `List
+               [ `String "Catch_all_noncompact_of_int"; int_to_json x_0 ]
+         | Catch_all_noncompact_other x_0 -> (
+             match x_0.payload with
+             | Stdlib.Option.None -> `String x_0.tag
+             | Stdlib.Option.Some xs -> `List (`String x_0.tag :: xs))
+        : catch_all_noncompact -> Yojson.Basic.t)
+  
+    let _ = catch_all_noncompact_to_json
+  end [@@ocaml.doc "@inline"] [@@merlin.hide]
+
+  $ cat <<"EOF" | run
   > type drop_default_option = { a: int; b_opt: int option; [@option] [@json.drop_default] } [@@deriving json]
   > EOF
   type drop_default_option = {


### PR DESCRIPTION
## Description

Remove the need to have len as an expected value name on `build_unknown_variant_case_record`, avoiding any `Error: Unbound value len`.
