### PR TITLE
Remove duplicated runtime dep

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Fix: remove the duplicated runtime deps from the `ppx` libraries.
 - Move the JSON Schema runtime into the main packages, at `Jsonkit.Jsonschema`.
   It is the same API under a new path, on both backends, so sources shared
   between a native and a Melange build need no per-backend conditionals. The

--- a/ppx/browser/dune
+++ b/ppx/browser/dune
@@ -3,7 +3,7 @@
  (name ppx_deriving_json_js)
  (modules :standard \ ppx_deriving_json_js_test)
  (libraries ppxlib)
- (ppx_runtime_libraries jsonkit-melange jsonkit-melange.jsonschema)
+ (ppx_runtime_libraries jsonkit-melange)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_deriver))

--- a/ppx/native/dune
+++ b/ppx/native/dune
@@ -3,7 +3,7 @@
  (name ppx_deriving_json_native)
  (modules :standard \ ppx_deriving_json_native_test)
  (libraries ppxlib)
- (ppx_runtime_libraries jsonkit yojson jsonkit.jsonschema)
+ (ppx_runtime_libraries jsonkit yojson)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_deriver))
@@ -55,7 +55,7 @@
 
 ; include_subdirs triggers a dependency cycle
 ; $ dune runtest
-; Error: Dependency cycle between:       
+; Error: Dependency cycle between:
 ;   alias .jsonkit-melange-files
 ; -> alias .jsonkit-files
 ; -> alias .jsonkit-melange-files


### PR DESCRIPTION
## Description

By mistake, the deprecated runtime library was included in the ppx libraries